### PR TITLE
fix(ngx-breadcrumbs): add support for underscore in resolved variables

### DIFF
--- a/projects/ngx-breadcrumbs/package.json
+++ b/projects/ngx-breadcrumbs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exalif/ngx-breadcrumbs",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "license": "MIT",
   "description": "Angular 4+ breadcrumbs on top of native Angular router",
   "author": {

--- a/projects/ngx-breadcrumbs/src/lib/utils/breadcrumbs.utils.ts
+++ b/projects/ngx-breadcrumbs/src/lib/utils/breadcrumbs.utils.ts
@@ -2,7 +2,7 @@ import { Observable, of, from } from 'rxjs';
 
 export abstract class BreadcrumbsUtils {
   public static stringFormat(rawTemplate: string, data: any): string {
-    const templateRegex = new RegExp('{{[\\s]*[a-zA-Z.]+?[\\s]*}}', 'g');
+    const templateRegex = new RegExp('{{[\\s]*[a-zA-Z._]+?[\\s]*}}', 'g');
 
     return rawTemplate.replace(templateRegex, (match) => {
       const keyRegex = new RegExp('([a-zA-Z.]+)', 'g');


### PR DESCRIPTION
Fix in 9.0.1

Closes: #60 