### PR TITLE
refact(ngx-breadcrumbs): add option to disable distinct behavior

### DIFF
--- a/projects/ngx-breadcrumbs/README.md
+++ b/projects/ngx-breadcrumbs/README.md
@@ -37,7 +37,9 @@ $ yarn add @exalif/ngx-breadcrumbs
 ## Usage
 
 Import the `BreadcrumbsModule` in your root module (`app.module.ts`) after 
-importing the _router_ module. 
+importing the _router_ module.
+
+You can provide an initial `BreadcrumbsConfig` as `forRoot` argument. By default, if no config is provided, the applied config will correspond to the one provided in the following example:
 
 ```typescript
 import { RouterModule } from '@angular/router';
@@ -46,7 +48,10 @@ import { BreadcrumbsModule } from '@exalif/ngx-breadcrumbs';
 @NgModule({
   imports: [
     RouterModule.forRoot(myRoutes),
-    BreadcrumbsModule.forRoot()
+    BreadcrumbsModule.forRoot({
+      postProcess: null,
+      applyDistinctOn: 'text',
+    }),
   ],  
 })
 export class AppModule {}
@@ -296,4 +301,31 @@ export class AppModule {
     };
   }
 }
+```
+
+**applyDistinctOn**
+
+By default, `distinct` rxjs operator is applied on `text` key of `Breadcrumb`, not to add crumbs with same text in the breadcrumbs array. If this is not correct behavior in your app, you can change `applyDistinctOn` key to another `Breadcrumb` key or to `null` to disable this behavior. 
+
+Signature:
+
+```typescript
+applyDistinctOn: DistinctKey | null = 'text';
+```
+
+Usage example to remove `distinct` behavior:
+
+```typescript
+import { RouterModule } from '@angular/router';
+import { BreadcrumbsModule } from '@exalif/ngx-breadcrumbs';
+
+@NgModule({
+  imports: [
+    RouterModule.forRoot(myRoutes),
+    BreadcrumbsModule.forRoot({
+      applyDistinctOn: null,
+    }),
+  ],  
+})
+export class AppModule {}
 ```

--- a/projects/ngx-breadcrumbs/package.json
+++ b/projects/ngx-breadcrumbs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exalif/ngx-breadcrumbs",
-  "version": "9.0.2",
+  "version": "9.1.0",
   "license": "MIT",
   "description": "Angular 4+ breadcrumbs on top of native Angular router",
   "author": {
@@ -23,9 +23,9 @@
     "routing"
   ],
   "peerDependencies": {
-    "@angular/common": ">= 10.0.0 < 11.0.0",
-    "@angular/core": ">= 10.0.0 < 11.0.0",
-    "@angular/router": ">= 10.0.0 < 11.0.0",
+    "@angular/common": ">= 9.0.0 < 11.0.0",
+    "@angular/core": ">= 9.0.0 < 11.0.0",
+    "@angular/router": ">= 9.0.0 < 11.0.0",
     "rxjs": "^6.3.0"
   },
   "dependencies": {

--- a/projects/ngx-breadcrumbs/src/lib/breadcrumbs.module.ts
+++ b/projects/ngx-breadcrumbs/src/lib/breadcrumbs.module.ts
@@ -9,19 +9,19 @@ import { BreadcrumbsComponent } from './component/breadcrumbs.component';
 @NgModule({
   imports: [
     CommonModule,
-    RouterModule
+    RouterModule,
   ],
   declarations: [BreadcrumbsComponent],
-  exports: [BreadcrumbsComponent]
+  exports: [BreadcrumbsComponent],
 })
 export class BreadcrumbsModule {
-  public static forRoot(): ModuleWithProviders<BreadcrumbsModule> {
+  public static forRoot(config?: Partial<BreadcrumbsConfig>): ModuleWithProviders<BreadcrumbsModule> {
     return {
       ngModule: BreadcrumbsModule,
       providers: [
-        BreadcrumbsConfig,
-        BreadcrumbsService
-      ]
+        { provide: BreadcrumbsConfig, useFactory: () => new BreadcrumbsConfig(config) },
+        BreadcrumbsService,
+      ],
     };
   }
 }

--- a/projects/ngx-breadcrumbs/src/lib/breadcrumbs.module.ts
+++ b/projects/ngx-breadcrumbs/src/lib/breadcrumbs.module.ts
@@ -6,6 +6,7 @@ import { BreadcrumbsConfig } from './services/breadcrumbs.config';
 import { BreadcrumbsService } from './services/breadcrumbs.service';
 import { BreadcrumbsComponent } from './component/breadcrumbs.component';
 
+// @dynamic
 @NgModule({
   imports: [
     CommonModule,
@@ -15,7 +16,7 @@ import { BreadcrumbsComponent } from './component/breadcrumbs.component';
   exports: [BreadcrumbsComponent],
 })
 export class BreadcrumbsModule {
-  public static forRoot(config?: Partial<BreadcrumbsConfig>): ModuleWithProviders<BreadcrumbsModule> {
+  public static forRoot(config?: BreadcrumbsConfig): ModuleWithProviders<BreadcrumbsModule> {
     return {
       ngModule: BreadcrumbsModule,
       providers: [

--- a/projects/ngx-breadcrumbs/src/lib/component/breadcrumbs.component.ts
+++ b/projects/ngx-breadcrumbs/src/lib/component/breadcrumbs.component.ts
@@ -5,6 +5,7 @@ import { Observable } from 'rxjs';
 
 import { BreadcrumbsService } from '../services/breadcrumbs.service';
 import { Breadcrumb } from '../models/breadcrumb';
+import { distinct, distinctUntilChanged } from 'rxjs/operators';
 
 @Component({
   selector: 'lib-breadcrumbs',

--- a/projects/ngx-breadcrumbs/src/lib/component/breadcrumbs.component.ts
+++ b/projects/ngx-breadcrumbs/src/lib/component/breadcrumbs.component.ts
@@ -5,7 +5,6 @@ import { Observable } from 'rxjs';
 
 import { BreadcrumbsService } from '../services/breadcrumbs.service';
 import { Breadcrumb } from '../models/breadcrumb';
-import { distinct, distinctUntilChanged } from 'rxjs/operators';
 
 @Component({
   selector: 'lib-breadcrumbs',

--- a/projects/ngx-breadcrumbs/src/lib/services/breadcrumbs.config.ts
+++ b/projects/ngx-breadcrumbs/src/lib/services/breadcrumbs.config.ts
@@ -14,7 +14,7 @@ export class BreadcrumbsConfig {
   public postProcess: PostProcessFunction | null = null;
   public applyDistinctOn: DistinctKey | null = 'text';
 
-  constructor(options: Partial<BreadcrumbsConfig> = {
+  constructor(options: BreadcrumbsConfig = {
     postProcess: null,
     applyDistinctOn: 'text',
   }) {

--- a/projects/ngx-breadcrumbs/src/lib/services/breadcrumbs.config.ts
+++ b/projects/ngx-breadcrumbs/src/lib/services/breadcrumbs.config.ts
@@ -7,7 +7,23 @@ import { Breadcrumb } from '../models/breadcrumb';
 export type PostProcessFunction =
   (crumbs: Breadcrumb[]) => Promise<Breadcrumb[]> | Observable<Breadcrumb[]> | Breadcrumb[];
 
+export type DistinctKey = keyof Breadcrumb;
+
 @Injectable()
 export class BreadcrumbsConfig {
-  postProcess: PostProcessFunction;
+  public postProcess: PostProcessFunction | null = null;
+  public applyDistinctOn: DistinctKey | null = 'text';
+
+  constructor(options: Partial<BreadcrumbsConfig> = {
+    postProcess: null,
+    applyDistinctOn: 'text',
+  }) {
+    if (!options) {
+      return;
+    }
+
+    Object.keys(options).forEach((optionKey) => {
+      this[optionKey] = options[optionKey];
+    });
+  }
 }


### PR DESCRIPTION
By default, `distinct` rxjs operator was applied, restricting having multiple breadcrumbs with identical text. 

This PR introduces a new `BreadcrumbsConfig` option named `applyDistinctOn`, defaulting to `text` to apply or not a distinct behavior on breadcrumbs service.

README updated accordingly.

Also fixed peer dependencies as Angular 9 is supported by version 9+ of the library.

closes: #64 