### PR TITLE
refact(ngx-file-upload): support backend data configuration

### DIFF
--- a/projects/ngx-file-upload/package.json
+++ b/projects/ngx-file-upload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exalif/ngx-file-upload",
-  "version": "15.0.0",
+  "version": "15.1.0",
   "license": "MIT",
   "description": "Angular 7+ file uploader with resume and chunks",
   "author": {

--- a/projects/ngx-file-upload/src/lib/models/upload-options.ts
+++ b/projects/ngx-file-upload/src/lib/models/upload-options.ts
@@ -101,6 +101,13 @@ export class NgxFileUploadOptions {
   useBackendUploadId?: boolean;
 
   /**
+   * Key name for backend provided upload id. Used only if useBackendUploadId option is enabled
+   *
+   * @defaultValue 'uploadId'
+   */
+  backendUploadIdName?: string;
+
+  /**
    * Append upload id to endpoint to get the upload endpoint path
    * e.g. with `uploadId = 'someid'` the upload endpoint will become `endpoint/someId`
    *
@@ -110,7 +117,7 @@ export class NgxFileUploadOptions {
 
   /**
    * Send file using formData instead of raw body.
-   * Setting this to false will send a application/octet-stream Content-Type Header
+   * Setting this to false will send an application/octet-stream Content-Type Header
    *
    * @defaultValue false
    */

--- a/projects/ngx-file-upload/src/lib/models/upload-options.ts
+++ b/projects/ngx-file-upload/src/lib/models/upload-options.ts
@@ -139,6 +139,14 @@ export class NgxFileUploadOptions {
   breakRetryErrorCodes?: number[];
 
   /**
+   * A success codes array for chuck response
+   * if a code matching an array element occurs, it will pass to the next chunk
+   *
+   * @defaultValue [300]
+   */
+  chuckSuccessCodes?: number[];
+
+  /**
    * Checksum Hash method
    */
   checksumHashMethod?: (file: File) => Promise<string>;

--- a/projects/ngx-file-upload/src/lib/models/upload-state.ts
+++ b/projects/ngx-file-upload/src/lib/models/upload-state.ts
@@ -13,6 +13,7 @@ export interface NgxFileUploadState {
   speed: number;
   status: NgxFileUploadStatus;
   uploadId: string;
+  chunkCount: number;
 
   /* eslint-disable-next-line @typescript-eslint/naming-convention */
   URI: string;

--- a/projects/ngx-file-upload/src/lib/models/uploader-options.ts
+++ b/projects/ngx-file-upload/src/lib/models/uploader-options.ts
@@ -6,6 +6,7 @@ export interface NgxFileUploaderOptions extends NgxFileUploadItem {
   withCredentials?: boolean;
   useDataFromPostResponseBody?: boolean;
   useBackendUploadId?: boolean;
+  backendUploadIdName?: string;
   useUploadIdAsUrlPath?: boolean;
   useFormData?: boolean;
   breakRetryErrorCodes?: number[];

--- a/projects/ngx-file-upload/src/lib/models/uploader-options.ts
+++ b/projects/ngx-file-upload/src/lib/models/uploader-options.ts
@@ -10,6 +10,7 @@ export interface NgxFileUploaderOptions extends NgxFileUploadItem {
   useUploadIdAsUrlPath?: boolean;
   useFormData?: boolean;
   breakRetryErrorCodes?: number[];
+  chuckSuccessCodes?: number[];
   formDataFileKey?: string;
 
   readonly stateChange?: any;

--- a/projects/ngx-file-upload/src/lib/ngx-file-upload.service.ts
+++ b/projects/ngx-file-upload/src/lib/ngx-file-upload.service.ts
@@ -53,6 +53,7 @@ export class NgxFileUploadService {
       maxRetryAttempts: this.options.maxRetryAttempts,
       useDataFromPostResponseBody: this.options.useDataFromPostResponseBody,
       useBackendUploadId: this.options.useBackendUploadId,
+      backendUploadIdName: this.options.backendUploadIdName || 'uploadId',
       useUploadIdAsUrlPath: this.options.useUploadIdAsUrlPath,
       useFormData: this.options.useFormData,
       formDataFileKey: this.options.formDataFileKey || 'file',
@@ -100,7 +101,7 @@ export class NgxFileUploadService {
    *
    * Create Uploader and add to the queue
    */
-  public async handleFileList(fileList: FileList, extraMedatata?: { [key: string]: any }) {
+  public async handleFileList(fileList: FileList, extraMetadata?: { [key: string]: any }) {
     for (let i = 0; i < fileList.length; i++) {
       let checkSum: string = null;
 
@@ -108,7 +109,7 @@ export class NgxFileUploadService {
         checkSum = await this.options.checksumHashMethod(fileList.item(i));
       }
 
-      const uploader: Uploader = new Uploader(fileList.item(i), this.uploaderOptions, checkSum, extraMedatata);
+      const uploader: Uploader = new Uploader(fileList.item(i), this.uploaderOptions, checkSum, extraMetadata);
       this.queue.push(uploader);
       uploader.status = 'added';
     }
@@ -119,14 +120,14 @@ export class NgxFileUploadService {
   /**
    * Create Uploader for the file and add to the queue
    */
-  public async handleFile(file: File, extraMedatata?: { [key: string]: any }) {
+  public async handleFile(file: File, extraMetadata?: { [key: string]: any }) {
     let checkSum: string = null;
 
     if (this.options.checksumHashMethod) {
       checkSum = await this.options.checksumHashMethod(file);
     }
 
-    const uploader: Uploader = new Uploader(file, this.uploaderOptions, checkSum, extraMedatata);
+    const uploader: Uploader = new Uploader(file, this.uploaderOptions, checkSum, extraMetadata);
     this.queue.push(uploader);
     uploader.status = 'added';
 

--- a/projects/ngx-file-upload/src/lib/ngx-file-upload.service.ts
+++ b/projects/ngx-file-upload/src/lib/ngx-file-upload.service.ts
@@ -58,6 +58,7 @@ export class NgxFileUploadService {
       useFormData: this.options.useFormData,
       formDataFileKey: this.options.formDataFileKey || 'file',
       breakRetryErrorCodes: this.options.breakRetryErrorCodes,
+      chuckSuccessCodes: this.options.chuckSuccessCodes,
       stateChange: this.stateChange,
     };
   }

--- a/projects/ngx-file-upload/src/lib/ngx-file-upload.service.ts
+++ b/projects/ngx-file-upload/src/lib/ngx-file-upload.service.ts
@@ -58,7 +58,7 @@ export class NgxFileUploadService {
       useFormData: this.options.useFormData,
       formDataFileKey: this.options.formDataFileKey || 'file',
       breakRetryErrorCodes: this.options.breakRetryErrorCodes,
-      chuckSuccessCodes: this.options.chuckSuccessCodes,
+      chuckSuccessCodes: this.options.chuckSuccessCodes || [300],
       stateChange: this.stateChange,
     };
   }

--- a/projects/ngx-file-upload/src/lib/utils/uploader.ts
+++ b/projects/ngx-file-upload/src/lib/utils/uploader.ts
@@ -375,10 +375,8 @@ export class Uploader {
     };
 
     const onSuccess = () => {
-      const allowedResponseCodes: number[] = this.chuckSuccessCodes;
-
       this.processResponse(xhr);
-      const offset = allowedResponseCodes.includes(this.statusType) && this.getNextChunkOffset(xhr);
+      const offset = this.chuckSuccessCodes.includes(this.statusType) && this.getNextChunkOffset(xhr);
 
       const allowRanges: boolean = !this.useChunksIndexes && typeof offset === 'number';
       const allowChunk: boolean = this.canGoToNextIndexChunk() && typeof offset === 'number';


### PR DESCRIPTION
- Add chunkCount in response
- Dynamic key name for backend "uploadId" response
- Spread extraMetadata in metadata for creation body
- Fix: allow to chunk with chunkSize configuration
- Fix: last chunk check
- Add "chuck success codes from backend response" parameter
- Fix: get location only when needed
- Fix some typo